### PR TITLE
[WIP] Bug on linux

### DIFF
--- a/jitome.go
+++ b/jitome.go
@@ -5,6 +5,7 @@ import (
 	"github.com/go-fsnotify/fsnotify"
 	"log"
 	"os"
+    "regexp"
 	"path/filepath"
 	"time"
 )
@@ -140,6 +141,7 @@ func runBufferedEventsRegister(bufferedEvents chan fsnotify.Event, events chan f
 }
 
 func startTaskWithPath(event *fsnotify.Event, path string) {
+    path = normalizePath(path)
 	for name, task := range config.Tasks {
 		if task.Match(path) {
 			printLog("<info:bold>Detected changing:</info:bold> " + path)
@@ -148,6 +150,17 @@ func startTaskWithPath(event *fsnotify.Event, path string) {
 			printLog("<info:bold>Finished:</info:bold> <comment>" + name + "</comment>")
 		}
 	}
+}
+
+func normalizePath(path string) string {
+    // remove "./"
+    // https://github.com/kohkimakimoto/jitome/pull/2
+    reg :=  regexp.MustCompile("^\\./")
+    nPath := reg.ReplaceAllString(path, "")
+
+    printDebugLog("Nomalize path '" + path + "' to '" + nPath + "'.")
+
+    return nPath
 }
 
 func runEventsRegister(events chan<- fsnotify.Event, watcher *fsnotify.Watcher) {


### PR DESCRIPTION
I found a bug on linux platform. 

I set up a configuration file setting a watch pattern is '*'. (means all files) 
When I created a file that name is 'a.txt', Jitome detected creation on OSX platform. but on Linux (CentOS6), Jitome could not detect it.

The following is log messages osx and linux.

```
## osx
[2015-03-10T16:51:22+09:00] Booted using .jitome
[2015-03-10T16:51:22+09:00] Walks watched directories: .
[2015-03-10T16:51:22+09:00] Added Watched dir: .
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/bin
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/composer
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/branches
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/hooks
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/info
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/logs
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/logs/refs
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/logs/refs/heads
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/logs/refs/remotes
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/logs/refs/remotes/composer
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/logs/refs/remotes/origin
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/objects
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/objects/info
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/objects/pack
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/refs
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/refs/heads
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/refs/remotes
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/refs/remotes/composer
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/refs/remotes/origin
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/refs/tags
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/bin
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/libexec
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/libexec/darwin
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/libexec/linux
[2015-03-10T16:51:22+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/libexec/windows
[2015-03-10T16:51:22+09:00] Booted event loop for watching.
[2015-03-10T16:51:36+09:00] Got a event (Create) about: a.txt
[2015-03-10T16:51:36+09:00] Matched '*' (a.txt)
[2015-03-10T16:51:36+09:00] Detected changing: a.txt
[2015-03-10T16:51:36+09:00] Starting: build
[2015-03-10T16:51:36+09:00] Command: cat $FILE
[2015-03-10T16:51:36+09:00] Finished: build
```

```
## linux
[2015-03-10T16:50:53+09:00] Booted using .jitome
[2015-03-10T16:50:53+09:00] Walks watched directories: .
[2015-03-10T16:50:53+09:00] Added Watched dir: .
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/bin
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/composer
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/branches
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/hooks
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/info
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/logs
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/logs/refs
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/logs/refs/heads
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/logs/refs/remotes
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/logs/refs/remotes/composer
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/objects
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/objects/info
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/objects/pack
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/refs
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/refs/heads
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/refs/remotes
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/refs/remotes/composer
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/refs/remotes/origin
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/.git/refs/tags
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/bin
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/libexec
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/libexec/darwin
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/libexec/linux
[2015-03-10T16:50:53+09:00] Added Watched dir: vendor/kohkimakimoto/jitome/libexec/windows
[2015-03-10T16:50:53+09:00] Booted event loop for watching.
[2015-03-10T16:51:24+09:00] Got a event (Create) about: ./a.txt
[2015-03-10T16:51:24+09:00] Unmatched '*' (./a.txt)
```
